### PR TITLE
speed improvements for the import script

### DIFF
--- a/import-clinvar-xml.py
+++ b/import-clinvar-xml.py
@@ -35,7 +35,7 @@ standard_methods = [
 ]
 
 def connect():
-    return sqlite3.connect(':memory:', timeout=600)
+    return sqlite3.connect('clinvar.db', timeout=600)
 
 def create_tables():
     db = connect()
@@ -362,6 +362,4 @@ if __name__ == '__main__':
     db = create_tables()
     for filename in argv[1:]:
         import_file(db, filename)
-    with sqlite3.connect('clinvar.db') as clinvardb:
-        db.backup(clinvardb, pages=14000)
     db.close()


### PR DESCRIPTION
I was able to index April release of ClinVar in a reasonable amount of time but with May release of ClinVar my import process did not return after several hours.
After making the following changes my  _import-clinvar-xml.py_ process is now returning in about 4 minutes and ClinVarMiner looks happy with the generated clinvar.db file:

- Move _date_ join conditions to WHERE clause
- Add indexes on _scv_ and _significance_ fields
- Delete completed parser processes earlier
